### PR TITLE
add collectionVariables

### DIFF
--- a/lib/shim/core.js
+++ b/lib/shim/core.js
@@ -538,6 +538,22 @@ const pm = Object.freeze({
     },
   }),
 
+  collectionVariables: Object.freeze({
+    clear() {
+      scope.collection = new Dict();
+    },
+    get(name) {
+      return scope.collection[name];
+    },
+    set(name, value) {
+      requireRequest();
+      scope.collection = scope.collection[Write](name, value);
+    },
+    unset(name) {
+      scope.collection = scope.collection[Clear](name);
+    },
+  }),
+
   /**
    * Evaluate variable
    *
@@ -564,6 +580,7 @@ function exposePm() {
     request: pm.request,
     sendRequest: pm.sendRequest,
     variables: pm.variables,
+    collectionVariables: pm.collectionVariables,
     [Var]: pm[Var],
   };
   if (state.data) {

--- a/test/com/shim/var.js
+++ b/test/com/shim/var.js
@@ -428,6 +428,33 @@ test.serial('pm.variables.set set', t => {
   });
 });
 
+test.serial('pm.collectionVariables.set scoped', t => {
+  t.throws(() => {
+    pm.collectionVariables.set('test', 'a');
+  });
+});
+
+test.serial('pm.collectionVariables.set clear', t => {
+  postman[Request]({
+    pre() {
+      t.is(pm.collectionVariables.get('test'), undef);
+      pm.collectionVariables.set('test', 'a');
+      t.is(pm.collectionVariables.get('test'), 'a');
+    }
+  });
+});
+
+test.serial('pm.collectionVariables.set set', t => {
+  postman[Request]({
+    pre() {
+      pm.collectionVariables.set('test', 'a');
+      t.is(pm.collectionVariables.get('test'), 'a');
+      pm.collectionVariables.set('test', 'b');
+      t.is(pm.collectionVariables.get('test'), 'b');
+    }
+  });
+});
+
 test.serial('pm[Var] simple', t => {
   postman[Initial]({ global: { test: 'a' } });
   t.is(pm[Var]('test'), 'a');


### PR DESCRIPTION
Expose some [collectionVariables](https://learning.postman.com/docs/writing-scripts/script-references/postman-sandbox-api-reference/#using-collection-variables-in-scripts) related methods, so that I can retain my postman collection without manually updating post converted script.