### PR TITLE
Postman requests take into account K6 param options

### DIFF
--- a/lib/shim/core.js
+++ b/lib/shim/core.js
@@ -1080,15 +1080,15 @@ function evaluateDataObject(data) {
 function makeRequestArgs ({ method, address, data, headers, options }) {
   // Set K6 request params from setting
   if (setting.options) {
-    options = Object.assign(setting.options, options)
+    options = Object.assign(setting.options, options);
   }
-  let requestHeaders = headers
+  let requestHeaders = headers;
   // Merge setting headers & request headers
   if (setting.options && setting.options.headers) {
-    requestHeaders = Object.assign(setting.options.headers, headers)
+    requestHeaders = Object.assign(setting.options.headers, headers);
   }
-  options.headers = requestHeaders
-  return [method, address, data, options]
+  options.headers = requestHeaders;
+  return [method, address, data, options];
 }
 function enterRequest(name, id, method, address, data, headers) {
   state.request = true;

--- a/lib/shim/core.js
+++ b/lib/shim/core.js
@@ -1077,9 +1077,18 @@ function evaluateDataObject(data) {
     }
   }
 }
-function makeRequestArgs({ method, address, data, headers, options }) {
-  options.headers = headers;
-  return [method, address, data, options];
+function makeRequestArgs ({ method, address, data, headers, options }) {
+  // Set K6 request params from setting
+  if (setting.options) {
+    options = Object.assign(setting.options, options)
+  }
+  let requestHeaders = headers
+  // Merge setting headers & request headers
+  if (setting.options && setting.options.headers) {
+    requestHeaders = Object.assign(setting.options.headers, headers)
+  }
+  options.headers = requestHeaders
+  return [method, address, data, options]
 }
 function enterRequest(name, id, method, address, data, headers) {
   state.request = true;


### PR DESCRIPTION
This is a PR to provide support in the Postman request for passing K6 params that are globally defined.

https://k6.io/docs/javascript-api/k6-http/params

Example
```
export default function () {
  let params = {
    cookies: { my_cookie: 'value' },
    headers: { 'X-MyHeader': 'k6test' },
    redirects: 5,
    tags: { k6test: 'yes' },
  };
  let res = http.get('https://k6.io', params);
}
```

It seemed that the Postman request function does not uses all the "options", when executing the http.request via K6.

Example script.js file

```
// Auto-generated by the Load Impact converter

import "./libs/shim/core.js";
import { group } from "k6";
import "./requests/Lists/Get-all-list-configurations.js";

export let options = { maxRedirects: 4 , headers: { 'Content-Type': 'application/json' } };

const Request = Symbol.for("request");
postman[Symbol.for("initial")]({
  options,
  collection: {
    baseUrl: "https://example.com/api"
  },
  environment: {
    baseUrl: "https://example.com/api"
  }
});

...
```

Which results in the following K6 call

```
INFO[0006] Request:
GET /api/lists/v2?$top=100&$skip=0&$count=false HTTP/1.1
User-Agent: k6/0.29.0 (https://k6.io/)
Content-Type: application/x-www-form-urlencoded
Accept-Encoding: gzip
```

The PR adds the passing of `let options` configurations, when making the K6 requests.

`export let options = { maxRedirects: 4 , headers: { 'Content-Type': 'application/json' } };`

Which results in
```
INFO[0006] Request:
GET /api/lists/v2?$top=100&$skip=0&$count=false HTTP/1.1
User-Agent: k6/0.29.0 (https://k6.io/)
Content-Type: application/json
Accept-Encoding: gzip
```

This PR would allow the possibility to leverage any K6 Params https://k6.io/docs/javascript-api/k6-http/params to be used when executing the Postman Request via K6.
