### PR TITLE
Added CLI support to pass K6 request parameter options

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,18 @@ Pass in a data file in the JSON format.
 $ postman-to-k6 collection.json --json data.json -o k6-script.js
 ```
 
+### K6 Param Options File
+
+Pass [K6 parameter options](https://k6.io/docs/javascript-api/k6-http/params) as a file in JSON format.
+
+| Flag | Verbose       | Default |
+| ---- | ------------- | ------- |
+|      | `--k6-params` | N/A     |
+
+```shell
+$ postman-to-k6 collection.json --k6-params k6-params.json -o k6-script.js
+```
+
 ### Separate
 
 Split requests into separate files, for easier rearrangement of the logic.

--- a/bin/postman-to-k6.js
+++ b/bin/postman-to-k6.js
@@ -21,7 +21,7 @@ program
   .option('-e, --environment <path>', 'JSON export of environment.')
   .option('-c, --csv <path>', 'CSV data file. Used to fill data variables.')
   .option('-j, --json <path>', 'JSON data file. Used to fill data variables.')
-  .option('--k6-params <path>', 'K6 params config file. Used to fill set the K6 params used during HTTP requests.')
+  .option('--k6-params <path>', 'K6 param options config file. Used to set the K6 params used during HTTP requests.')
   .option('--skip-pre', 'Skips pre-request scripts')
   .option('--skip-post', 'Skips post-request scripts')
   .option('--oauth1-consumer-key <value>', 'OAuth1 consumer key.')

--- a/bin/postman-to-k6.js
+++ b/bin/postman-to-k6.js
@@ -21,6 +21,7 @@ program
   .option('-e, --environment <path>', 'JSON export of environment.')
   .option('-c, --csv <path>', 'CSV data file. Used to fill data variables.')
   .option('-j, --json <path>', 'JSON data file. Used to fill data variables.')
+  .option('--k6-params <path>', 'K6 params config file. Used to fill set the K6 params used during HTTP requests.')
   .option('--skip-pre', 'Skips pre-request scripts')
   .option('--skip-post', 'Skips post-request scripts')
   .option('--oauth1-consumer-key <value>', 'OAuth1 consumer key.')
@@ -94,6 +95,7 @@ function translateOptions(options) {
     environment: options.environment,
     csv: !!options.csv,
     json: !!options.json,
+    k6Params: options.k6Params,
     iterations: options.iterations,
     id: true,
     oauth1: translateOauth1Options(options),

--- a/example/v2/k6-params.json
+++ b/example/v2/k6-params.json
@@ -1,0 +1,6 @@
+{
+  "maxRedirects": 6,
+  "headers": {
+    "Content-Type": "application/json"
+  }
+}

--- a/lib/convert/file.js
+++ b/lib/convert/file.js
@@ -28,6 +28,18 @@ async function convertFile(path, options = {}) {
       );
     }
   }
+  if (options.k6Params) {
+    try {
+      options.k6Params = fs.readFileSync(options.k6Params, {
+        encoding: 'utf8',
+      });
+    } catch (e) {
+      throw new ReadError(
+        e,
+        `Could not read K6 params file: ${options.k6Params}`
+      );
+    }
+  }
   return convertJson(text, options);
 }
 

--- a/lib/convert/json.js
+++ b/lib/convert/json.js
@@ -23,6 +23,13 @@ async function convertJson(collectionJson, options = {}) {
       throw new ParseError(e, 'Failed to parse environment JSON');
     }
   }
+  if (options.k6Params) {
+    try {
+      options.k6Params = JSON.parse(stripJsonComments(options.k6Params));
+    } catch (e) {
+      throw new ParseError(e, 'Failed to parse k6 Params JSON');
+    }
+  }
   return convertObject(collection, options);
 }
 

--- a/lib/convert/object.js
+++ b/lib/convert/object.js
@@ -43,6 +43,9 @@ async function convertObject(collection, options = {}) {
   if (options.environment) {
     Environment(options.environment, result);
   }
+  if (options.k6Params) {
+    result.options = Object.assign({}, result.options, options.k6Params);
+  }
   if (options.separate) {
     separate(node, result);
   }


### PR DESCRIPTION
This PR extends the CLI to allow setting the K6 options that are being used when the Postman requests are generated.

This makes it possible to pass / overwrite the option
Typically these options are rendered:

`export let options = { maxRedirects: 4 };`

By using `--k6-params` like in this example

` postman-to-k6 collection.json -o k6-script.js --k6-params ./k6-params.json`

The default options will get changed into 

`export let options = { maxRedirects: 4 , headers: { 'Content-Type': 'application/json' } };`

Because the "k6-params.json" contained:

```
{
  "maxRedirects": 6,
  "headers": {
    "Content-Type": "application/json"
  }
}
```