### PR TITLE
Fix to handle spaces in the query part

### DIFF
--- a/lib/generate/Request/analyze.js
+++ b/lib/generate/Request/analyze.js
@@ -48,7 +48,9 @@ function address(address, feature, result) {
   let urijsPath = './libs/shim/urijs.js';
   if (aid.variableStart.test(addressText)) {
     // Runtime scheme processing necessary
-    feature.address = new URI(addressText);
+    const addressURI = new URI(addressText);
+    const addressQuery = addressURI.query().replace(' ','%20'); // Handle spaces in the query
+    feature.address = addressURI.query(addressQuery);
     // Handle urijs import for separate option
     if (
       result.setting &&

--- a/lib/generate/Request/analyze.js
+++ b/lib/generate/Request/analyze.js
@@ -48,9 +48,7 @@ function address(address, feature, result) {
   let urijsPath = './libs/shim/urijs.js';
   if (aid.variableStart.test(addressText)) {
     // Runtime scheme processing necessary
-    const addressURI = new URI(addressText);
-    const addressQuery = addressURI.query().replace(/\s/g, '%20'); // Handle spaces in the query
-    feature.address = addressURI.query(addressQuery);
+    feature.address = new URI(addressText);
     // Handle urijs import for separate option
     if (
       result.setting &&
@@ -67,6 +65,7 @@ function address(address, feature, result) {
     // Scheme missing
     feature.address = new URI(`http://${addressText}`);
   }
+  feature.address = feature.address.query(feature.address.query().replace(/\s/g, '%20'));
 }
 
 function data(request, feature, result) {

--- a/lib/generate/Request/analyze.js
+++ b/lib/generate/Request/analyze.js
@@ -49,7 +49,7 @@ function address(address, feature, result) {
   if (aid.variableStart.test(addressText)) {
     // Runtime scheme processing necessary
     const addressURI = new URI(addressText);
-    const addressQuery = addressURI.query().replace(' ','%20'); // Handle spaces in the query
+    const addressQuery = addressURI.query().replace(/\s/g, '%20'); // Handle spaces in the query
     feature.address = addressURI.query(addressQuery);
     // Handle urijs import for separate option
     if (

--- a/lib/generate/Request/analyze.js
+++ b/lib/generate/Request/analyze.js
@@ -65,7 +65,7 @@ function address(address, feature, result) {
     // Scheme missing
     feature.address = new URI(`http://${addressText}`);
   }
-  feature.address = feature.address.query(feature.address.query().replace(/\s/g, '%20'));
+  feature.address = feature.address.query(URI.encodeReserved(feature.address.query()));
 }
 
 function data(request, feature, result) {


### PR DESCRIPTION
When using spaces in the query part, postman properly handles this on execution time (see the CURL part)
![image](https://user-images.githubusercontent.com/952446/117317307-b0821600-ae89-11eb-96dd-201e52b849e4.png)

The conversion just keeps the space, which results in a strange error in K6.
This PR fixes this by doing an additional replace of spaces in the 

Example of the Postman screenshot in the generated request in script.js.
```
import "../../libs/shim/urijs.js";

postman[Symbol.for("define")]({
  name: "Get the list of long running API operations",
  id: "ddf9d157-cb31-4f5a-843d-76a48b862f40",
  method: "GET",
  address:
    "{{baseUrl}}/platform/v1/operations?$orderby=lastAction asc&$top=100&$skip=0&$count=false",
  post(response) {
    // Validate status 2xx
    pm.test("[GET] /platform/v1/operations - Status code is 2xx", function() {
      pm.response.to.be.success;
    });
  }
});

```

K6 error:
```
INFO[0007] Request:
GET /api/platform/v1/operations?$orderby=lastAction asc&$top=100&$skip=0&$count=false HTTP/1.1
Host: example.com
User-Agent: k6/0.29.0 (https://k6.io/)
Content-Type: application/json
Accept-Encoding: gzip

  group="::smc-operations" iter=0 request_id=adbbe9ed-58a1-4dc0-6ddf-5f7e5530a452 scenario=default source=http-debug vu=1
INFO[0007] Response:
HTTP/2.0 505 HTTP Version Not Supported
```


